### PR TITLE
fix: Use absolute import for config

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, Depends, HTTPException, Security
 from fastapi.security import APIKeyHeader
 
 from .api.endpoints import quiz
-from ..config import SECRET_TOKEN
+from config import SECRET_TOKEN
 
 app = FastAPI(title="Religious Questions Bot API")
 


### PR DESCRIPTION
This commit fixes an `ImportError` that occurred when starting the application. The `app/main.py` file was using a relative import to access the `config.py` file, which is not compatible with how the application is being run with `uvicorn`.

This change converts the relative import `from ..config import SECRET_TOKEN` to an absolute import `from config import SECRET_TOKEN` to resolve the error.