### PR TITLE
fix: Prevent race condition in quiz creation

### DIFF
--- a/app/api/endpoints/quiz.py
+++ b/app/api/endpoints/quiz.py
@@ -75,6 +75,9 @@ async def start_competition(request: quiz_models.StartCompetitionRequest):
     await redis_handler.set_current_question(request.bot_token, request.channel_id, first_question['id'], end_time)
     await redis_handler.redis_client.hset(redis_handler.quiz_key(request.bot_token, request.channel_id), "current_index", 0)
 
+    # Activate the quiz so the worker can pick it up
+    await redis_handler.activate_quiz(request.bot_token, request.channel_id)
+
     logger.info(f"Competition started successfully for bot {request.bot_token} in channel {request.channel_id}")
     return {"message": "Competition started."}
 

--- a/app/redis_client/redis_handler.py
+++ b/app/redis_client/redis_handler.py
@@ -29,7 +29,7 @@ def answered_key(bot_token: str, chat_id: str, question_id: int, user_id: int) -
 async def start_quiz(bot_token: str, chat_id: str, message_id: int, questions_db_path: str, stats_db_path: str, question_ids: list, time_per_question: int, creator_id: int):
     key = quiz_key(bot_token, chat_id)
     quiz_data = {
-        "status": "active",
+        "status": "initializing",
         "question_ids": json.dumps(question_ids),
         "current_index": -1,
         "time_per_question": time_per_question,
@@ -42,6 +42,10 @@ async def start_quiz(bot_token: str, chat_id: str, message_id: int, questions_db
         "stats_db_path": stats_db_path
     }
     await redis_client.hmset(key, quiz_data)
+
+async def activate_quiz(bot_token: str, chat_id: str):
+    key = quiz_key(bot_token, chat_id)
+    await redis_client.hset(key, "status", "active")
 
 async def get_quiz_status(bot_token: str, chat_id: str):
     key = quiz_key(bot_token, chat_id)


### PR DESCRIPTION
A race condition was occurring between the API and the background processing during quiz creation. The API would create a quiz in an 'active' state, but before it was fully configured, it could be picked up and processed, leading to premature termination of the quiz.

This commit fixes the race condition by introducing an 'initializing' state for quizzes. The quiz is now created with `status: 'initializing'`. The API then fully configures the quiz, sends the first question, and only then updates the status to 'active'. The background processing will only process quizzes that are in the 'active' state, thus preventing it from acting on partially created quizzes.